### PR TITLE
Hapi wreck updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@hapi/hoek": "^8.5.0",
     "@hapi/joi": "^16.1.7",
-    "@hapi/wreck": "^16.0.1",
+    "@hapi/wreck": "^17.0.0",
     "circuit-state": "^1.0.0",
     "cuid": "^2.0.0",
     "debug": "^4.0.0",


### PR DESCRIPTION
This update solves an issue with empty buffers, instead of returning the buffer, it returns null. This behavior is caused by @hapi/wreck.

## Description
Hapi wreck version updated to 17.0.0

## Motivation and Context
This removes the error of "Empty buffer", the newer version of wreck returns a null instead.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
